### PR TITLE
Disable LibC-based file enumeration on MacOS

### DIFF
--- a/src/main/java/build/buildfarm/common/IOUtils.java
+++ b/src/main/java/build/buildfarm/common/IOUtils.java
@@ -195,7 +195,7 @@ public class IOUtils {
   public static List<NamedFileKey> listDirentSorted(Path path, FileStore fileStore)
       throws IOException {
     final List<NamedFileKey> dirents;
-    if (fileStore.supportsFileAttributeView("posix")) {
+    if (fileStore.supportsFileAttributeView("posix") && !System.getProperty("os.name").equals("Mac OS X")) {
       dirents = ffiReaddir(libc.get(), runtime(), path);
     } else {
       dirents = listNIOdirentSorted(path);


### PR DESCRIPTION
The build farm seems to list corrupt files on startup:
java.nio.file.NoSuchFileException: /private/var/lib/buildfarm/cache/2d337a34434ad71984ac9cb157d506ee84730da3ce896f4e05a67fe2014222f8_79_dir/#

While related to invalid cache entry listings on startup
https://github.com/bazelbuild/bazel-buildfarm/issues/433
there are reasons to suspect that the problem affects the
cache as well, as builds are frequently reporting
grpc errors on MacOS but not on Linux: BulkTransferException (5)
(entity not found)